### PR TITLE
support falsy replacement values (includes tests)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,37 +1,42 @@
 {
-  "name": "babel-plugin-transform-define",
-  "description": "Babel plugin that replaces member expressions and typeof statements with strings",
-  "version": "1.2.0",
+  "name"            : "babel-plugin-transform-define",
+  "description"     : "Babel plugin that replaces member expressions and typeof statements with strings",
+
+  "version"         : "1.2.0",
   "contributors": [
     "Eric Baer <me@ericbaer.com> (https://github.com/baer)",
     "Michael Jackson <mjijackson@gmail.com> (https://github.com/mjackson)",
     "Andy Edwards <jedwards@fastmail.com> (https://github.com/jedwards1211)"
   ],
-  "homepage": "https://github.com/FormidableLabs/babel-plugin-transform-define",
+
+  "homepage"        : "https://github.com/FormidableLabs/babel-plugin-transform-define",
   "bugs": {
     "url": "https://github.com/FormidableLabs/babel-plugin-transform-define/issues"
   },
-  "repository": "git://github.com/FormidableLabs/babel-plugin-transform-define.git",
-  "private": false,
+
+  "repository"      : "git://github.com/FormidableLabs/babel-plugin-transform-define.git",
+  "private"         : false,
+
   "dependencies": {
-    "lodash.get": "4.4.2",
-    "lodash.has": "4.5.2",
-    "traverse": "0.6.6"
+    "lodash"                   : "4.17.4",
+    "traverse"                 : "0.6.6"
   },
   "devDependencies": {
-    "assert-transform": "^1.0.0",
-    "babel-cli": "^6.6.5",
-    "babel-core": "^6.13.2",
-    "babel-eslint": "6.1.2",
-    "babel-preset-es2015": "^6.6.0",
-    "eslint": "2.10.2",
-    "eslint-config-formidable": "1.0.1",
-    "eslint-plugin-filenames": "1.1.0",
-    "eslint-plugin-import": "1.13.0",
-    "mocha": "^3.0.2",
-    "rimraf": "^2.5.2"
+    "assert-transform"         : "^1.0.0",
+    "babel-core"               : "^6.13.2",
+    "babel-cli"                : "^6.6.5",
+    "babel-eslint"             : "6.1.2",
+    "babel-preset-es2015"      : "^6.6.0",
+    "eslint-config-formidable" : "1.0.1",
+    "eslint-plugin-filenames"  : "1.1.0",
+    "eslint-plugin-import"     : "1.13.0",
+    "eslint"                   : "2.10.2",
+    "mocha"                    : "^3.0.2",
+    "rimraf"                   : "^2.5.2"
   },
-  "main": "lib",
+
+  "main" : "lib",
+
   "scripts": {
     "build": "babel ./src -d lib",
     "check": "npm run clean && npm run build && npm run test && npm run lint",
@@ -41,10 +46,13 @@
     "release": "node ./scripts/release.js",
     "test": "mocha ./test/index.js"
   },
-  "engines": {
+
+  "engines":{
     "node": ">= 4.x.x"
   },
-  "license": "MIT",
+
+  "license"         : "MIT",
+
   "keywords": [
     "babel-plugin",
     "babel-transform",

--- a/package.json
+++ b/package.json
@@ -1,41 +1,37 @@
 {
-  "name"            : "babel-plugin-transform-define",
-  "description"     : "Babel plugin that replaces member expressions and typeof statements with strings",
-
-  "version"         : "1.2.0",
+  "name": "babel-plugin-transform-define",
+  "description": "Babel plugin that replaces member expressions and typeof statements with strings",
+  "version": "1.2.0",
   "contributors": [
     "Eric Baer <me@ericbaer.com> (https://github.com/baer)",
-    "Michael Jackson <mjijackson@gmail.com> (https://github.com/mjackson)"
+    "Michael Jackson <mjijackson@gmail.com> (https://github.com/mjackson)",
+    "Andy Edwards <jedwards@fastmail.com> (https://github.com/jedwards1211)"
   ],
-
-  "homepage"        : "https://github.com/FormidableLabs/babel-plugin-transform-define",
+  "homepage": "https://github.com/FormidableLabs/babel-plugin-transform-define",
   "bugs": {
     "url": "https://github.com/FormidableLabs/babel-plugin-transform-define/issues"
   },
-
-  "repository"      : "git://github.com/FormidableLabs/babel-plugin-transform-define.git",
-  "private"         : false,
-
+  "repository": "git://github.com/FormidableLabs/babel-plugin-transform-define.git",
+  "private": false,
   "dependencies": {
-    "lodash.get"               : "4.4.2",
-    "traverse"                 : "0.6.6"
+    "lodash.get": "4.4.2",
+    "lodash.has": "4.5.2",
+    "traverse": "0.6.6"
   },
   "devDependencies": {
-    "assert-transform"         : "^1.0.0",
-    "babel-core"               : "^6.13.2",
-    "babel-cli"                : "^6.6.5",
-    "babel-eslint"             : "6.1.2",
-    "babel-preset-es2015"      : "^6.6.0",
-    "eslint-config-formidable" : "1.0.1",
-    "eslint-plugin-filenames"  : "1.1.0",
-    "eslint-plugin-import"     : "1.13.0",
-    "eslint"                   : "2.10.2",
-    "mocha"                    : "^3.0.2",
-    "rimraf"                   : "^2.5.2"
+    "assert-transform": "^1.0.0",
+    "babel-cli": "^6.6.5",
+    "babel-core": "^6.13.2",
+    "babel-eslint": "6.1.2",
+    "babel-preset-es2015": "^6.6.0",
+    "eslint": "2.10.2",
+    "eslint-config-formidable": "1.0.1",
+    "eslint-plugin-filenames": "1.1.0",
+    "eslint-plugin-import": "1.13.0",
+    "mocha": "^3.0.2",
+    "rimraf": "^2.5.2"
   },
-
-  "main" : "lib",
-
+  "main": "lib",
   "scripts": {
     "build": "babel ./src -d lib",
     "check": "npm run clean && npm run build && npm run test && npm run lint",
@@ -45,13 +41,10 @@
     "release": "node ./scripts/release.js",
     "test": "mocha ./test/index.js"
   },
-
-  "engines":{
+  "engines": {
     "node": ">= 4.x.x"
   },
-
-  "license"         : "MIT",
-
+  "license": "MIT",
   "keywords": [
     "babel-plugin",
     "babel-transform",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 const fs = require("fs");
 const path = require("path");
 const traverse = require("traverse");
-const {get, has, find} = require("lodash");
+const { get, has, find } = require("lodash");
 
 /**
  * Return an Array of every possible non-cyclic path in the object as a dot separated string sorted

--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,20 @@ const replaceAndEvaluateNode = (replaceFn, nodePath, replacement) => {
 };
 
 /**
+ * Finds the first element of an array for which the given predicate returns true.
+ * (we don't want to rely on Array.find() being present in the user's environment)
+ * @param {Array}      array        The array to search
+ * @param {function}   predicate    A function that will be called for each element in the array
+ * @return the first element for which `predicate(element)` is truthy, otherwise `undefined`.
+const find = (array, predicate) => {
+  for (let index = 0; index < array.length; index++) {
+    const element = array[index];
+    if (predicate(element)) return element;
+  }
+  return undefined;
+}
+
+/**
  * Finds the first replacement in sorted object paths for replacements that causes comparator
  * to return true.  If one is found, replaces the node with it.
  * @param  {Object}     replacements The object to search for replacements
@@ -76,8 +90,8 @@ const replaceAndEvaluateNode = (replaceFn, nodePath, replacement) => {
  * @return {undefined}
  */
 const processNode = (replacements, nodePath, replaceFn, comparator) => { // eslint-disable-line
-  const replacementKey = getSortedObjectPaths(replacements)
-    .find((value) => comparator(nodePath, value));
+  const replacementKey = find(getSortedObjectPaths(replacements),
+    (value) => comparator(nodePath, value));
   if (has(replacements, replacementKey)) {
     replaceAndEvaluateNode(replaceFn, nodePath, get(replacements, replacementKey));
   }

--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,8 @@ const replaceAndEvaluateNode = (replaceFn, nodePath, replacement) => {
 };
 
 /**
- * Run the transformation over a node
+ * Finds the first replacement in sorted object paths for replacements that causes comparator
+ * to return true.  If one is found, replaces the node with it.
  * @param  {Object}     replacements The object to search for replacements
  * @param  {babelNode}  nodePath     The node to evaluate
  * @param  {function}   replaceFn    The function used to replace the node
@@ -76,8 +77,7 @@ const replaceAndEvaluateNode = (replaceFn, nodePath, replacement) => {
  */
 const processNode = (replacements, nodePath, replaceFn, comparator) => { // eslint-disable-line
   const replacementKey = getSortedObjectPaths(replacements)
-    .filter((value) => comparator(nodePath, value))
-    .shift();
+    .find((value) => comparator(nodePath, value));
   if (has(replacements, replacementKey)) {
     replaceAndEvaluateNode(replaceFn, nodePath, get(replacements, replacementKey));
   }

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ const fs = require("fs");
 const path = require("path");
 const traverse = require("traverse");
 const get = require("lodash.get");
+const has = require("lodash.has");
 
 /**
  * Return an Array of every possible non-cyclic path in the object as a dot separated string sorted
@@ -66,20 +67,6 @@ const replaceAndEvaluateNode = (replaceFn, nodePath, replacement) => {
 };
 
 /**
- * Get the first value in the `obj` that causes the comparator to return true
- * @param  {Object}     obj         The object to search for replacements
- * @param  {function}   comparator  The function used to evaluate whether a node matches a value in `obj`
- * @param  {babelNode}  nodePath    The node to evaluate
- * @return {*}  The first matching value to replace OR null
- */
-const getFirstReplacementValueForNode = (obj, comparator, nodePath) => {
-  const replacementKey = getSortedObjectPaths(obj)
-    .filter((value) => comparator(nodePath, value))
-    .shift();
-  return get(obj, replacementKey) || null;
-};
-
-/**
  * Run the transformation over a node
  * @param  {Object}     replacements The object to search for replacements
  * @param  {babelNode}  nodePath     The node to evaluate
@@ -88,9 +75,11 @@ const getFirstReplacementValueForNode = (obj, comparator, nodePath) => {
  * @return {undefined}
  */
 const processNode = (replacements, nodePath, replaceFn, comparator) => { // eslint-disable-line
-  const replacement = getFirstReplacementValueForNode(replacements, comparator, nodePath);
-  if (replacement) {
-    replaceAndEvaluateNode(replaceFn, nodePath, replacement);
+  const replacementKey = getSortedObjectPaths(replacements)
+    .filter((value) => comparator(nodePath, value))
+    .shift();
+  if (has(replacements, replacementKey)) {
+    replaceAndEvaluateNode(replaceFn, nodePath, get(replacements, replacementKey));
   }
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -71,14 +71,17 @@ const replaceAndEvaluateNode = (replaceFn, nodePath, replacement) => {
  * (we don't want to rely on Array.find() being present in the user's environment)
  * @param {Array}      array        The array to search
  * @param {function}   predicate    A function that will be called for each element in the array
- * @return the first element for which `predicate(element)` is truthy, otherwise `undefined`.
+ * @return {any} the first element for which `predicate(element)` is truthy, otherwise `undefined`.
+ */
 const find = (array, predicate) => {
   for (let index = 0; index < array.length; index++) {
     const element = array[index];
-    if (predicate(element)) return element;
+    if (predicate(element)) {
+      return element;
+    }
   }
   return undefined;
-}
+};
 
 /**
  * Finds the first replacement in sorted object paths for replacements that causes comparator

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,7 @@
 const fs = require("fs");
 const path = require("path");
 const traverse = require("traverse");
-const get = require("lodash.get");
-const has = require("lodash.has");
+const {get, has, find} = require("lodash");
 
 /**
  * Return an Array of every possible non-cyclic path in the object as a dot separated string sorted
@@ -64,23 +63,6 @@ const replaceAndEvaluateNode = (replaceFn, nodePath, replacement) => {
       nodePath.parentPath.replaceWith(replaceFn(result.value));
     }
   }
-};
-
-/**
- * Finds the first element of an array for which the given predicate returns true.
- * (we don't want to rely on Array.find() being present in the user's environment)
- * @param {Array}      array        The array to search
- * @param {function}   predicate    A function that will be called for each element in the array
- * @return {any} the first element for which `predicate(element)` is truthy, otherwise `undefined`.
- */
-const find = (array, predicate) => {
-  for (let index = 0; index < array.length; index++) {
-    const element = array[index];
-    if (predicate(element)) {
-      return element;
-    }
-  }
-  return undefined;
 };
 
 /**

--- a/test/0/actual.js
+++ b/test/0/actual.js
@@ -1,0 +1,8 @@
+var x = PRODUCTION;
+
+if (!PRODUCTION) {
+  console.log('Debug info');
+}
+if (PRODUCTION) {
+  console.log('Production log');
+}

--- a/test/0/expected.js
+++ b/test/0/expected.js
@@ -1,0 +1,10 @@
+'use strict';
+
+var x = 0;
+
+if (!0) {
+  console.log('Debug info');
+}
+if (0) {
+  console.log('Production log');
+}

--- a/test/emptyString/actual.js
+++ b/test/emptyString/actual.js
@@ -1,0 +1,8 @@
+var x = PRODUCTION;
+
+if (!PRODUCTION) {
+  console.log('Debug info');
+}
+if (PRODUCTION) {
+  console.log('Production log');
+}

--- a/test/emptyString/expected.js
+++ b/test/emptyString/expected.js
@@ -1,0 +1,10 @@
+'use strict';
+
+var x = '';
+
+if (!'') {
+  console.log('Debug info');
+}
+if ('') {
+  console.log('Production log');
+}

--- a/test/false/actual.js
+++ b/test/false/actual.js
@@ -1,0 +1,8 @@
+var x = PRODUCTION;
+
+if (!PRODUCTION) {
+  console.log('Debug info');
+}
+if (PRODUCTION) {
+  console.log('Production log');
+}

--- a/test/false/expected.js
+++ b/test/false/expected.js
@@ -1,0 +1,10 @@
+'use strict';
+
+var x = false;
+
+if (!false) {
+  console.log('Debug info');
+}
+if (false) {
+  console.log('Production log');
+}

--- a/test/index.js
+++ b/test/index.js
@@ -71,6 +71,56 @@ describe("babel-plugin-transform-define", () => {
         path.join(__dirname, "./identifier/expected.js"), babelOpts);
     });
 
+    it("should transform false", () => {
+      const babelOpts = getBabelOps({
+        "PRODUCTION": false
+      });
+
+      return assertTransform(
+        path.join(__dirname, "./false/actual.js"),
+        path.join(__dirname, "./false/expected.js"), babelOpts);
+    })
+
+    it("should transform 0", () => {
+      const babelOpts = getBabelOps({
+        "PRODUCTION": 0
+      });
+
+      return assertTransform(
+        path.join(__dirname, "./0/actual.js"),
+        path.join(__dirname, "./0/expected.js"), babelOpts);
+    })
+
+    it("should transform empty string", () => {
+      const babelOpts = getBabelOps({
+        "PRODUCTION": ''
+      });
+
+      return assertTransform(
+        path.join(__dirname, "./emptyString/actual.js"),
+        path.join(__dirname, "./emptyString/expected.js"), babelOpts);
+    })
+
+    it("should transform null", () => {
+      const babelOpts = getBabelOps({
+        "PRODUCTION": null
+      });
+
+      return assertTransform(
+        path.join(__dirname, "./null/actual.js"),
+        path.join(__dirname, "./null/expected.js"), babelOpts);
+    })
+
+    it("should transform undefined", () => {
+      const babelOpts = getBabelOps({
+        "PRODUCTION": undefined
+      });
+
+      return assertTransform(
+        path.join(__dirname, "./undefined/actual.js"),
+        path.join(__dirname, "./undefined/expected.js"), babelOpts);
+    })
+
     it("should transform code from config in a file", () => {
       const babelOpts = getBabelOps("./test/load-config-file/config.js");
 

--- a/test/null/actual.js
+++ b/test/null/actual.js
@@ -1,0 +1,8 @@
+var x = PRODUCTION;
+
+if (!PRODUCTION) {
+  console.log('Debug info');
+}
+if (PRODUCTION) {
+  console.log('Production log');
+}

--- a/test/null/expected.js
+++ b/test/null/expected.js
@@ -1,0 +1,10 @@
+'use strict';
+
+var x = null;
+
+if (!null) {
+  console.log('Debug info');
+}
+if (null) {
+  console.log('Production log');
+}

--- a/test/undefined/actual.js
+++ b/test/undefined/actual.js
@@ -1,0 +1,8 @@
+var x = PRODUCTION;
+
+if (!PRODUCTION) {
+  console.log('Debug info');
+}
+if (PRODUCTION) {
+  console.log('Production log');
+}

--- a/test/undefined/expected.js
+++ b/test/undefined/expected.js
@@ -1,0 +1,10 @@
+'use strict';
+
+var x = undefined;
+
+if (!undefined) {
+  console.log('Debug info');
+}
+if (undefined) {
+  console.log('Production log');
+}


### PR DESCRIPTION
the current version doesn't perform replacements with falsy values because `getFirstReplacementValueForNode ` returns `get(obj, replacementKey) || null`, and `processNode` does `if (replacement)`.

This change uses `lodash.has` to check if the `replacementKey` is present in `replacements`, and if so, performs the replacement -- even if it's `null`, `0`, `''`, `false`, `NaN`, or `undefined`.