### PR TITLE
fix the sort comparator

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ export const getSortedObjectPaths = (obj) => {
     .paths()
     .filter((arr) => arr.length)
     .map((arr) => arr.join("."))
-    .sort((elem) => elem.length);
+    .sort((a, b) => b.length - a.length);
 };
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -152,7 +152,7 @@ describe("babel-plugin-transform-define", () => {
       it("should return a list sorted by length", () => {
         const obj = { process: { env: { NODE_ENV: "development" } } };
         const objectPaths = babelPluginTransformDefine.getSortedObjectPaths(obj);
-        assert.deepEqual(objectPaths, objectPaths.sort((elem) => elem.length));
+        assert.deepEqual(objectPaths, objectPaths.sort((a, b) => b.length - a.length));
       });
     });
   });


### PR DESCRIPTION
The comparator function of Array.prototype.sort expects two arguments to compare (https://tc39.github.io/ecma262/#sec-array.prototype.sort)

The previous implementation used a 1-element comparator, which always returns the length of the first element. That this resulted in the correct ordering in a test is pure luck.