### PR TITLE
Search parent directories for config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 lib
+node_modules
+.vscode

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
 
   "dependencies": {
     "lodash"                   : "4.17.4",
-    "traverse"                 : "0.6.6"
+    "traverse"                 : "0.6.6",
+    "find-parent-dir"          : "0.3.0"
   },
   "devDependencies": {
     "assert-transform"         : "^1.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ const fs = require("fs");
 const path = require("path");
 const traverse = require("traverse");
 const { get, has, find } = require("lodash");
+const findParentDir = require("find-parent-dir");
 
 /**
  * Return an Array of every possible non-cyclic path in the object as a dot separated string sorted
@@ -31,11 +32,12 @@ export const getSortedObjectPaths = (obj) => {
  * @param  {Object|String}  configOptions  configuration to parse
  * @return {Object}  replacement object
  */
-const getReplacements = (configOptions) => {
+export const getReplacements = (configOptions) => {
   if (typeof configOptions === "object") { return configOptions; }
 
   try {
-    const fullPath = path.join(process.cwd(), configOptions);
+    const dir = findParentDir.sync(process.cwd(), configOptions);
+    const fullPath = path.join(dir, configOptions);
     fs.accessSync(fullPath, fs.F_OK);
     return require(fullPath);
   } catch (err) {

--- a/test/index.js
+++ b/test/index.js
@@ -155,5 +155,37 @@ describe("babel-plugin-transform-define", () => {
         assert.deepEqual(objectPaths, objectPaths.sort((elem) => elem.length));
       });
     });
+
+    describe("getReplacements", () => {
+      const config = {
+        "process.env.NODE_ENV": "development"
+      };
+      const cwd = process.cwd();
+      afterEach(() => {
+        process.chdir(cwd)
+      })
+
+      it("should return replacements object unmodified", () => {
+        const result = babelPluginTransformDefine.getReplacements(config);
+        assert.deepEqual(result, config);
+      });
+
+      it("should read config file", () => {
+        const result = babelPluginTransformDefine.getReplacements("./test/load-config-file/config.js");
+        assert.deepEqual(result, config);
+      });
+
+      it("should read config file in current directory", () => {
+        process.chdir('./test/load-config-file');
+        const result = babelPluginTransformDefine.getReplacements("config.js");
+        assert.deepEqual(result, config);
+      });
+
+      it("should read config file in parent directory", () => {
+        process.chdir('./test/load-config-file/sub');
+        const result = babelPluginTransformDefine.getReplacements('config.js');
+        assert.deepEqual(result, config);
+      });
+    });
   });
 });

--- a/test/load-config-file/sub/empty
+++ b/test/load-config-file/sub/empty
@@ -1,0 +1,1 @@
+Placeholder for test loading config file from parent directory.


### PR DESCRIPTION
I was having problems using this plugin with react-native. The issue is that the react-native packager (metro) runs in a subdirectory of node_modules. However, my tests run from the root directory of my package. So they need different paths for the config file passed to transform-define.

This searches recursively for the config file specified as an argument to the plugin. It follows pattern from .babelrc node_modules, etc.
