### PR TITLE
Fix vulnerabilities found via npm audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,42 +1,36 @@
 {
-  "name"            : "babel-plugin-transform-define",
-  "description"     : "Babel plugin that replaces member expressions and typeof statements with strings",
-
-  "version"         : "1.3.0",
+  "name": "babel-plugin-transform-define",
+  "description": "Babel plugin that replaces member expressions and typeof statements with strings",
+  "version": "1.3.0",
   "contributors": [
     "Eric Baer <me@ericbaer.com> (https://github.com/baer)",
     "Michael Jackson <mjijackson@gmail.com> (https://github.com/mjackson)",
     "Andy Edwards <jedwards@fastmail.com> (https://github.com/jedwards1211)"
   ],
-
-  "homepage"        : "https://github.com/FormidableLabs/babel-plugin-transform-define",
+  "homepage": "https://github.com/FormidableLabs/babel-plugin-transform-define",
   "bugs": {
     "url": "https://github.com/FormidableLabs/babel-plugin-transform-define/issues"
   },
-
-  "repository"      : "git://github.com/FormidableLabs/babel-plugin-transform-define.git",
-  "private"         : false,
-
+  "repository": "git://github.com/FormidableLabs/babel-plugin-transform-define.git",
+  "private": false,
   "dependencies": {
-    "lodash"                   : "4.17.4",
-    "traverse"                 : "0.6.6"
+    "lodash": "^4.17.11",
+    "traverse": "0.6.6"
   },
   "devDependencies": {
-    "assert-transform"         : "^1.0.0",
-    "babel-core"               : "^6.13.2",
-    "babel-cli"                : "^6.6.5",
-    "babel-eslint"             : "6.1.2",
-    "babel-preset-es2015"      : "^6.6.0",
-    "eslint-config-formidable" : "3.0.0",
-    "eslint-plugin-filenames"  : "1.1.0",
-    "eslint-plugin-import"     : "1.13.0",
-    "eslint"                   : "3.19.0",
-    "mocha"                    : "^3.0.2",
-    "rimraf"                   : "^2.5.2"
+    "assert-transform": "^1.0.0",
+    "babel-cli": "^6.6.5",
+    "babel-core": "^6.13.2",
+    "babel-eslint": "6.1.2",
+    "babel-preset-es2015": "^6.6.0",
+    "eslint": "3.19.0",
+    "eslint-config-formidable": "3.0.0",
+    "eslint-plugin-filenames": "1.1.0",
+    "eslint-plugin-import": "1.13.0",
+    "mocha": "^5.2.0",
+    "rimraf": "^2.5.2"
   },
-
-  "main" : "lib",
-
+  "main": "lib",
   "scripts": {
     "build": "babel ./src -d lib",
     "check": "npm run clean && npm run build && npm run test && npm run lint",
@@ -46,13 +40,10 @@
     "release": "node ./scripts/release.js",
     "test": "mocha ./test/index.js"
   },
-
-  "engines":{
+  "engines": {
     "node": ">= 4.x.x"
   },
-
-  "license"         : "MIT",
-
+  "license": "MIT",
   "keywords": [
     "babel-plugin",
     "babel-transform",


### PR DESCRIPTION
## Issue
Found the following when running `npm install`
```sh
added 504 packages from 282 contributors, updated 11 packages and audited 4150 packages in 10.457s
found 189 vulnerabilities (188 low, 1 critical)
  run `npm audit fix` to fix them, or `npm audit` for details
```

## What I've done
I've updated package.json to secure the packages.

## How to test
run `npm test`

```sh
  babel-plugin-transform-define
    transformation tests
      ✓ should transform Unary Expressions
      ✓ should transform Identifiers
      ✓ should transform false
      ✓ should transform 0
      ✓ should transform empty string
      ✓ should transform null
      ✓ should transform undefined
      ✓ should transform code from config in a file
      Member Expressions
        ✓ should transform with config defined by String keys
        ✓ should transform with config defined by an Object
    unit tests
      getSortedObjectPaths
        ✓ should return an array
        ✓ should return a complete list of paths
        ✓ should return a list sorted by length


  13 passing (253ms)
```

## Result
```sh
npm audit

                       === npm audit security report ===

found 0 vulnerabilities
 in 4143 scanned packages
```