### PR TITLE
Improve support for import identifiers, fixes #69

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 node_modules
+test/import-identifiers

--- a/lib/index.js
+++ b/lib/index.js
@@ -63,6 +63,28 @@ const processNode = (replacements, nodePath, replaceFn, comparator) => {
   }
 };
 
+/**
+ * Checks if the given identifier is a an ES module import
+ * @param  {babelNode} identifierNodePath The node to check
+ * @return {boolean} Indicates if the provided node is an import specifier or references one
+ */
+const isImportIdentifier = (identifierNodePath) => {
+  const name = get(identifierNodePath, ["node", "name"]);
+  const containerType = get(identifierNodePath, ["container", "type"]);
+
+  if (containerType === "ImportDefaultSpecifier" || containerType === "ImportSpecifier") {
+    return true;
+  }
+
+  // Check if the identifier references a module import of the same name
+  const binding = identifierNodePath.scope.getBinding(name);
+  if (binding && binding.kind === "module") {
+    return true;
+  }
+
+  return false;
+};
+
 const memberExpressionComparator = (nodePath, value) => nodePath.matchesPattern(value);
 const identifierComparator = (nodePath, value) => nodePath.node.name === value;
 const unaryExpressionComparator = (nodePath, value) => nodePath.node.argument.name === value;
@@ -79,6 +101,12 @@ const plugin = function ({ types: t }) {
 
       // const x = { version: VERSION };
       Identifier(nodePath, state) {
+        // Don't transform import idenifiers. This is meant to mimic webpack's
+        // DefinePlugin behavior.
+        if (isImportIdentifier(nodePath)) {
+          return;
+        }
+
         processNode(state.opts, nodePath, t.valueToNode, identifierComparator);
       },
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -64,7 +64,7 @@ const processNode = (replacements, nodePath, replaceFn, comparator) => {
 };
 
 /**
- * Checks if the given identifier is a an ES module import
+ * Checks if the given identifier is an ES module import
  * @param  {babelNode} identifierNodePath The node to check
  * @return {boolean} Indicates if the provided node is an import specifier or references one
  */

--- a/test/import-identifiers/actual.js
+++ b/test/import-identifiers/actual.js
@@ -1,0 +1,9 @@
+import DONT_REPLACE_ME, { DONT_REPLACE_ME_EITHER } from 'foo';
+
+DONT_REPLACE_ME;
+DONT_REPLACE_ME_EITHER;
+
+function childScope() {
+  DONT_REPLACE_ME;
+  DONT_REPLACE_ME_EITHER;
+}

--- a/test/import-identifiers/expected.js
+++ b/test/import-identifiers/expected.js
@@ -1,0 +1,9 @@
+import DONT_REPLACE_ME, { DONT_REPLACE_ME_EITHER } from 'foo';
+
+DONT_REPLACE_ME;
+DONT_REPLACE_ME_EITHER;
+
+function childScope() {
+  DONT_REPLACE_ME;
+  DONT_REPLACE_ME_EITHER;
+}

--- a/test/index.js
+++ b/test/index.js
@@ -166,6 +166,21 @@ describe("babel-plugin-transform-define", () => {
       path.join(__dirname, "./load-dynamic-babelrc/actual.js"),
       path.join(__dirname, "./load-dynamic-babelrc/expected.js")
     ));
+
+    it("should not transform import identifiers", () => {
+      // Don't use `getBabelOpts` here cause we want to avoid preset-env which
+      // injects a bunch of extra code to handle es modules. It makes the test
+      // output harder to read.
+      const babelOpts = {
+        plugins: [
+          [path.resolve(__dirname, "../lib/index.js"), { DONT_REPLACE_ME: "injected" }]
+        ]
+      };
+
+      return assertTransform(
+        path.join(__dirname, "./import-identifiers/actual.js"),
+        path.join(__dirname, "./import-identifiers/expected.js"), babelOpts);
+    });
   });
 
   describe("unit tests", () => {


### PR DESCRIPTION
This PR fixes #69 by returning early during identifier traversal if it matches an ES module default or named import. I'm open to feedback if there's anything you think I missed!